### PR TITLE
Add optional file type filter

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -17,6 +17,7 @@ namespace QtcCppcheck {
     const char SETTINGS_CHECK_UNUSED[] = "checkUnused";
     const char SETTINGS_CHECK_INCONCLUSIVE[] = "checkInconclusive";
     const char SETTINGS_CUSTOM_PARAMS[] = "customParams";
+    const char SETTINGS_FILE_TYPES[] = "fileTypes";
     const char SETTINGS_SHOW_OUTPUT[] = "showOutput";
     const char SETTINGS_POPUP_ON_ERROR[] = "popupOnError";
     const char SETTINGS_POPUP_ON_WARNING[] = "popupOnWarning";

--- a/src/OptionsWidget.cpp
+++ b/src/OptionsWidget.cpp
@@ -105,6 +105,7 @@ void OptionsWidget::applySettings()
   settings_->setCheckUnused (ui->unusedCheckBox->isChecked ());
   settings_->setCheckInconclusive (ui->inconclusiveCheckBox->isChecked ());
   settings_->setCustomParameters (ui->customParametersEdit->text ());
+  settings_->setFileTypes (ui->fileTypesEdit->text ());
   settings_->setShowBinaryOutput (ui->showOutputCheckBox->isChecked ());
   settings_->setPopupOnError (ui->popupOnErrorCheckBox->isChecked ());
   settings_->setPopupOnWarning (ui->popupOnWarningCheckBox->isChecked ());
@@ -122,6 +123,7 @@ void OptionsWidget::initInterface()
   ui->unusedCheckBox->setChecked (settings_->checkUnused ());
   ui->inconclusiveCheckBox->setChecked (settings_->checkInconclusive ());
   ui->customParametersEdit->setText (settings_->customParameters ());
+  ui->fileTypesEdit->setText (settings_->fileTypes ());
   ui->showOutputCheckBox->setChecked (settings_->showBinaryOutput ());
   ui->popupOnErrorCheckBox->setChecked (settings_->popupOnError ());
   ui->popupOnWarningCheckBox->setChecked (settings_->popupOnWarning ());

--- a/src/OptionsWidget.ui
+++ b/src/OptionsWidget.ui
@@ -6,50 +6,71 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>313</height>
+    <width>591</width>
+    <height>324</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="0">
+   <item row="12" column="0">
     <widget class="QCheckBox" name="showOutputCheckBox">
      <property name="text">
       <string>Show binary's output</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="8" column="0">
     <widget class="QCheckBox" name="onProjectChangeCheckBox">
      <property name="text">
       <string>Check on active project change</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="10" column="0">
     <widget class="QCheckBox" name="unusedCheckBox">
      <property name="text">
       <string>Check for unused functions</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="7" column="1">
     <widget class="QCheckBox" name="onSaveCheckBox">
      <property name="text">
       <string>Check document on save</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="8" column="1">
     <widget class="QCheckBox" name="onFileAddedCheckBox">
      <property name="text">
       <string>Check added files</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="14" column="1">
+    <widget class="QCheckBox" name="popupOnWarningCheckBox">
+     <property name="text">
+      <string>Popup issues pane when warnings found</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QCheckBox" name="popupOnErrorCheckBox">
+     <property name="text">
+      <string>Popup issues pane when errors found</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QCheckBox" name="inconclusiveCheckBox">
+     <property name="text">
+      <string>Check for inconclusive errors</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
     <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -86,14 +107,7 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="1">
-    <widget class="QCheckBox" name="popupOnWarningCheckBox">
-     <property name="text">
-      <string>Popup issues pane when warnings found</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
+   <item row="11" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QLabel" name="label_3">
@@ -117,21 +131,21 @@
      </item>
     </layout>
    </item>
-   <item row="9" column="0">
-    <widget class="QCheckBox" name="popupOnErrorCheckBox">
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="onBuildCheckBox">
      <property name="text">
-      <string>Popup issues pane when errors found</string>
+      <string>Check project on build</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="13" column="0" colspan="2">
     <widget class="Line" name="line_3">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="15" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -144,13 +158,6 @@
      </property>
     </spacer>
    </item>
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="inconclusiveCheckBox">
-     <property name="text">
-      <string>Check for inconclusive errors</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0" colspan="2">
     <widget class="Line" name="line">
      <property name="orientation">
@@ -158,12 +165,46 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QCheckBox" name="onBuildCheckBox">
-     <property name="text">
-      <string>Check project on build</string>
-     </property>
-    </widget>
+   <item row="4" column="0" rowspan="3" colspan="2">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>File types to check: </string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="fileTypesEdit">
+         <property name="toolTip">
+          <string/>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="font">
+        <font>
+         <italic>true</italic>
+        </font>
+       </property>
+       <property name="text">
+        <string>List of file extensions separated by semicolons e.g. cpp;h;c</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -34,6 +34,7 @@ void Settings::save()
   settings.setValue (QLatin1String (SETTINGS_CHECK_UNUSED), checkUnused_);
   settings.setValue (QLatin1String (SETTINGS_CHECK_INCONCLUSIVE), checkInconclusive_);
   settings.setValue (QLatin1String (SETTINGS_CUSTOM_PARAMS), customParameters_);
+  settings.setValue (QLatin1String (SETTINGS_FILE_TYPES), fileTypes_);
   settings.setValue (QLatin1String (SETTINGS_SHOW_OUTPUT), showBinaryOutput_);
   settings.setValue (QLatin1String (SETTINGS_POPUP_ON_ERROR), popupOnError_);
   settings.setValue (QLatin1String (SETTINGS_POPUP_ON_WARNING), popupOnWarning_);
@@ -60,6 +61,8 @@ void Settings::load()
   checkInconclusive_ = settings.value (QLatin1String (SETTINGS_CHECK_INCONCLUSIVE),
                                        false).toBool ();
   customParameters_ = settings.value (QLatin1String (SETTINGS_CUSTOM_PARAMS),
+                                      QString ()).toString ();
+  fileTypes_ = settings.value (QLatin1String (SETTINGS_FILE_TYPES),
                                       QString ()).toString ();
   showBinaryOutput_ = settings.value (QLatin1String (SETTINGS_SHOW_OUTPUT),
                                       false).toBool ();
@@ -108,6 +111,17 @@ QString Settings::customParameters() const
 void Settings::setCustomParameters(const QString &customParameters)
 {
   customParameters_ = customParameters;
+}
+
+QString Settings::fileTypes() const
+{
+  return fileTypes_;
+}
+
+void Settings::setFileTypes(const QString &fileTypes)
+{
+
+  fileTypes_ = fileTypes;
 }
 
 bool Settings::showBinaryOutput() const

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -43,6 +43,9 @@ namespace QtcCppcheck {
         QString customParameters() const;
         void setCustomParameters(const QString &customParameters);
 
+        QString fileTypes() const;
+        void setFileTypes(const QString &fileTypes);
+
         bool showBinaryOutput() const;
         void setShowBinaryOutput(bool showBinaryOutput);
 
@@ -63,6 +66,7 @@ namespace QtcCppcheck {
         bool checkUnused_;
         bool checkInconclusive_;
         QString customParameters_;
+        QString fileTypes_;
         bool showBinaryOutput_;
 
         bool popupOnError_;


### PR DESCRIPTION
If you use "Import Existing Project" to create a project for existing
C++ code when you scan the project it scans all files. e.g. including
.jpg files which gives you lots of errors like:
download.jpg,1,error,unhandledCharacters,The code contains unhandled
characters (character code = 0xd8). Checking continues, but do not
expect valid results.

This adds an optional file type filter to the options and filters the
file list passed in to include just those types