### PR TITLE
Use Show Binary Output checkbox to control quiet (-q) flag usage.

### DIFF
--- a/src/CppcheckRunner.cpp
+++ b/src/CppcheckRunner.cpp
@@ -52,7 +52,8 @@ void CppcheckRunner::updateSettings()
   Q_ASSERT (settings_ != NULL);
   showOutput_ = settings_->showBinaryOutput ();
   runArguments_.clear ();
-  runArguments_ << QLatin1String ("-q");
+  if( ! showOutput_ )
+    runArguments_ << QLatin1String ("-q");
   // Pass custom params BEFORE most of runner's to shadow if some repeat.
   runArguments_ += settings_->customParameters ().split (
                      QLatin1Char (' '), QString::SkipEmptyParts);


### PR DESCRIPTION
Check the showBinaryOutput_ state before passing cppcheck the -q (quiet) flag.  If binary output is selected, do not pass the -q flag, so that the user gets decent progress output from cppcheck.  If binary output is not selected, pass the -q flag.