### PR TITLE
Fix crash when opening a project in debug mode

### DIFF
--- a/src/QtcCppcheckPlugin.cpp
+++ b/src/QtcCppcheckPlugin.cpp
@@ -304,8 +304,8 @@ void QtcCppcheckPlugin::updateProjectFileList()
 {
   if (activeProject_)
   {
-    Q_ASSERT (activeProject_->rootProjectNode () != NULL);
-    projectFileList_ = checkableFiles (activeProject_->rootProjectNode ());
+    if (ProjectNode *rootNode = activeProject_->rootProjectNode ())
+      projectFileList_ = checkableFiles (rootNode);
   }
 }
 


### PR DESCRIPTION
rootProjectNode is not assigned yet in startupProjectChanged.

When it is assigned, it invokes fileListChanged, which calls this slot again anyway.