### PR TITLE
Remove the experimental flag

### DIFF
--- a/QtcCppcheck.json.in
+++ b/QtcCppcheck.json.in
@@ -2,7 +2,6 @@
     \"Name\" : \"QtcCppcheck\",
     \"Version\" : \"$$QTCREATOR_VERSION$$VERSION_SUFFIX\",
     \"CompatVersion\" : \"$$QTCREATOR_COMPAT_VERSION\",
-    \"Experimental\" : true,
     \"Category\": \"Code Analyzer\",
     \"Vendor\" : \"Gres\",
     \"Copyright\" : \"(C) Gres\",


### PR DESCRIPTION
If the user built and/or installed this plugin, there's no reason to
disable it by default.

If/when the plugin is intended to go upstream this will make more sense.